### PR TITLE
removed d suffix - did not compile with VS2017

### DIFF
--- a/src/musselize.cxx
+++ b/src/musselize.cxx
@@ -14,8 +14,8 @@
  * A high boxiness value (greater than 2.0) indicates a very chaotic
  * shape that we are not interested in.
  */
-#define BOXINESS_CUTOFF_LO 1.18d
-#define BOXINESS_CUTOFF_HI 1.5d
+#define BOXINESS_CUTOFF_LO 1.18
+#define BOXINESS_CUTOFF_HI 1.5
 /*
  * The minimum area occupied by a possible mollusc.
  */


### PR DESCRIPTION
The d literal (probably meaning double?) isn't recognized by VS2017, the code can't be compiled. since the number should be a double anyway, the suffix should be removed.